### PR TITLE
Passing filename to check-contents

### DIFF
--- a/lib/flow-check-file.js
+++ b/lib/flow-check-file.js
@@ -7,9 +7,9 @@ const flow = require('flow-bin');
  * @param {string} content the contents of a file to check
  * @return {string[]} the JSON error messages from Flow
  */
-function checkFileContents(content) {
-  const result = spawnSync(flow, ['check-contents', '--color', 'always'], { 
-    input: content 
+function checkFileContents(content, filePath) {
+  const result = spawnSync(flow, ['check-contents', filePath, '--color', 'always'], {
+    input: content
   });
   const outputText = result.output[1].toString();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const PersistentFilter = require('broccoli-persistent-filter');
 const checkFileContents = require('./flow-check-file');
+const path = require('path');
 
 class FlowFilter extends PersistentFilter {
   constructor(inputNode, options = {}) {
@@ -16,8 +17,9 @@ class FlowFilter extends PersistentFilter {
     return 'js';
   }
 
-  processString(fileContent) {
-    const errorText = checkFileContents(fileContent);
+  processString(fileContent, fileName) {
+    const filePath = path.join(this.inputPaths[0], fileName);
+    const errorText = checkFileContents(fileContent, filePath);
 
     return {
       output: fileContent,


### PR DESCRIPTION
if filename is unknow, flow reports errors like this:
```
Error: -:3
```

also it is unable to resolve any relative imports. The errors look like this:
```
Error: -:3
  3: import Server from './server';
                        ^^^^^^^^^^ ./server. Required module not found
```

This PR follows the advice from https://github.com/facebook/flow/issues/1910#issuecomment-274900534

It makes the imports to work and errors look like this:
```
Error: src/server.js:14
 14:     this.actions = actions;
              ^^^^^^^ property `actions`. Property not found in
```
